### PR TITLE
Update stackTrace.odin because runtime.os_write was renamed

### DIFF
--- a/vendor/pdb/pdb/stackTrace.odin
+++ b/vendor/pdb/pdb/stackTrace.odin
@@ -433,7 +433,7 @@ print_u64_x :: proc "contextless" (x: u64) #no_bounds_check {
 	}
 	i -= 1; a[i] = digits[u % b]
 
-	runtime.os_write(a[i:])
+	runtime.stderr_write(a[i:])
 }
 
 print_source_code_location :: proc (using scl: runtime.Source_Code_Location) {


### PR DESCRIPTION
Fixes build error because `runtime.os_write` was renamed in this commit: https://github.com/odin-lang/Odin/commit/f0a7f1812f0884348f03f56bac7560bbb6eefbf8 