### PR TITLE
Use Unicode width proc for table.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 manual
 assert_backtrace
 allocator
+*.exe
 ols.json

--- a/back.odin
+++ b/back.odin
@@ -120,7 +120,7 @@ print :: proc(lines: []Line, padding := "    ", w: Maybe(io.Writer) = nil, no_te
 		table.row(tbl, padding, line.symbol, " - ", line.location)
 	}
 
-	table.build(tbl)
+	table.build(tbl, table.unicode_width_proc)
 
 	for row in 0..<tbl.nr_rows {
 		for col in 0..<tbl.nr_cols {


### PR DESCRIPTION
the recent odin release added a width proc argument for table.build, this fixes the compiler error

* use default unicode width proc for table.build
* add exe files to gitignore