### PR TITLE
Removed All Instances of `using` In Function Signatures

### DIFF
--- a/vendor/pdb/pdb/cvsRecord.odin
+++ b/vendor/pdb/pdb/cvsRecord.odin
@@ -411,7 +411,7 @@ CvsInlineUncompressedLine :: struct {
     fileIdx   : u16le,
 }
 
-read_cvsInlineSite :: proc(using this: ^BlocksReader, blockEnd: uint, $T: typeid) -> (ret: T)
+read_cvsInlineSite :: proc(this: ^BlocksReader, blockEnd: uint, $T: typeid) -> (ret: T)
     where intrinsics.type_is_subtype_of(T, CvsInlineSite) {
     ret._base = read_packed(this, type_of(ret._base))
     ret.lines = parse_binary_annotation(this, blockEnd)
@@ -434,7 +434,7 @@ BinaryAnnotationOpcode :: enum u8 {
     ChangeCodeLengthAndCodeOffset = 12, // (codeLength, codeOffset). emitting
     ChangeColumnEnd = 13, // set end column number
 }
-parse_binary_annotation :: proc(using this: ^BlocksReader, blockEnd: uint) -> (ret: []CvsInlineUncompressedLine) {
+parse_binary_annotation :: proc(this: ^BlocksReader, blockEnd: uint) -> (ret: []CvsInlineUncompressedLine) {
     baseOffset := this.offset
     // pase 1: count emiiting
     lineCount := 0
@@ -507,7 +507,7 @@ parse_binary_annotation :: proc(using this: ^BlocksReader, blockEnd: uint) -> (r
     }
     return
 }
-uncompress_binary_annonation :: proc(using this: ^BlocksReader) -> u32le {
+uncompress_binary_annonation :: proc(this: ^BlocksReader) -> u32le {
     b1 := u32le(read_packed(this, u8))
     if (b1 & 0x80) == 0 { return b1 }
     b2 := u32le(read_packed(this, u8))
@@ -516,7 +516,7 @@ uncompress_binary_annonation :: proc(using this: ^BlocksReader) -> u32le {
     b4 := u32le(read_packed(this, u8))
     return ((b1 & 0x1f) << 24) | (b2 << 16) | (b3 << 8) | b4
 }
-uncompress_binary_annonation_signed :: proc(using this: ^BlocksReader) -> i32le {
+uncompress_binary_annonation_signed :: proc(this: ^BlocksReader) -> i32le {
     u := uncompress_binary_annonation(this)
     if (u&1) != 0 { return -i32le(u>>1) }
     return i32le(u>>1)

--- a/vendor/pdb/pdb/dbiStream.odin
+++ b/vendor/pdb/pdb/dbiStream.odin
@@ -206,10 +206,10 @@ _cmp_sc :: #force_inline proc(l, r: SlimDbiSecContr) -> int {
     else if l.offset > r.offset { return 1 }
     return 0
 }
-search_for_section_contribution :: proc(using this: ^SlimDbiData, imgRva : u32le) -> (sci : int) {
+search_for_section_contribution :: proc(this: ^SlimDbiData, imgRva : u32le) -> (sci : int) {
     sectionIdx := -1
     offsetInSection :u32le= 0
-    for section, i in sections {
+    for section, i in this.sections {
         if imgRva >= section.vAddr && imgRva < section.vAddr + section.vSize {
             sectionIdx = i
             //log.debug(section)
@@ -220,13 +220,13 @@ search_for_section_contribution :: proc(using this: ^SlimDbiData, imgRva : u32le
     if sectionIdx == -1 { return -1 }
     // bisearch for module
     ti := SlimDbiSecContr{PESectionOffset{offsetInSection, u16le(sectionIdx+1),}, 0}
-    lo, hi := 0, (len(contributions)-1)
-    if hi < 0 || _cmp_sc(ti, contributions[lo]) < 0 { return -1 }
-    if _cmp_sc(contributions[hi], ti) < 0 { return int(hi) }
+    lo, hi := 0, (len(this.contributions)-1)
+    if hi < 0 || _cmp_sc(ti, this.contributions[lo]) < 0 { return -1 }
+    if _cmp_sc(this.contributions[hi], ti) < 0 { return int(hi) }
     // ti in range, do a bisearch
     for lo <= hi {
         mid := lo + ((hi-lo)>>1)
-        mv := _cmp_sc(ti, contributions[mid])
+        mv := _cmp_sc(ti, this.contributions[mid])
         if mv == 0 {
             lo = mid + 1
             break

--- a/vendor/pdb/pdb/hashTable.odin
+++ b/vendor/pdb/pdb/hashTable.odin
@@ -18,26 +18,26 @@ BitVector :: struct {
     words: []u32le,
 }
 
-get_kv_at :: proc(using this: ^PdbHashTable($T), at: u32le) -> (ret:PdbHashTable_KVPair(T), ok:bool) {
-    ok = get_bit(&presentBits, at)
+get_kv_at :: proc(this: ^PdbHashTable($T), at: u32le) -> (ret:PdbHashTable_KVPair(T), ok:bool) {
+    ok = get_bit(&this.presentBits, at)
     if !ok {
         ret = {}
         return
     }
-    ret = kvPairs[at]
+    ret = this.kvPairs[at]
     return
 }
 
-get_bit :: proc(using this: ^BitVector, at: u32le) -> bool {
+get_bit :: proc(this: ^BitVector, at: u32le) -> bool {
     ELEMENT_PER_WORD :: 32
     wi := at / ELEMENT_PER_WORD
-    if int(wi) >= len(words) { return false }
-    word := words[uint(wi)]
+    if int(wi) >= len(this.words) { return false }
+    word := this.words[uint(wi)]
     iiw := at - (wi * ELEMENT_PER_WORD)
     return (word & (1 << iiw)) != 0
 }
 
-read_hash_table :: proc(using this: ^BlocksReader, $Value: typeid) -> (ret:PdbHashTable(Value)) {
+read_hash_table :: proc(this: ^BlocksReader, $Value: typeid) -> (ret:PdbHashTable(Value)) {
     ret.size = read_packed(this, u32le)
     ret.capacity = read_packed(this, u32le)
     //log.debugf("hash_table size%v capacity%v", ret.size, ret.capacity)
@@ -57,7 +57,7 @@ read_hash_table :: proc(using this: ^BlocksReader, $Value: typeid) -> (ret:PdbHa
     return
 }
 
-read_bit_vector :: proc(using this: ^BlocksReader) -> (ret: BitVector) {
+read_bit_vector :: proc(this: ^BlocksReader) -> (ret: BitVector) {
     wordCount := read_packed(this, u32le)
     ret.words = read_packed_array(this, uint(wordCount), u32le)
     return

--- a/vendor/pdb/pdb/modStream.odin
+++ b/vendor/pdb/pdb/modStream.odin
@@ -197,17 +197,17 @@ SlimModInlineSrc :: struct {
     srcLineNum : u32le,
 }
 
-locate_pc :: proc(using data: ^SlimModData, func: PESectionOffset,  pcFromFunc: u32le) -> (csvProc:^SlimCvsProc, lineBlock: ^SlimModLineBlock, line: ^SlimModLinePos){
-    for i in 0..<len(procs) {
+locate_pc :: proc(data: ^SlimModData, func: PESectionOffset,  pcFromFunc: u32le) -> (csvProc:^SlimCvsProc, lineBlock: ^SlimModLineBlock, line: ^SlimModLinePos){
+    for i in 0..<len(data.procs) {
         //log.debugf("%d/%d:", i, )
-        p := &procs[i]
+        p := &data.procs[i]
         if p.secIdx == func.secIdx && p.offset == func.offset {
             csvProc = p
             break
         }
     }
-    for lbi in 0..<len(blocks) {
-        lb := &blocks[lbi]
+    for lbi in 0..<len(data.blocks) {
+        lb := &data.blocks[lbi]
         if lb.secIdx != func.secIdx || lb.offset != func.offset {
             continue
         }
@@ -224,20 +224,20 @@ locate_pc :: proc(using data: ^SlimModData, func: PESectionOffset,  pcFromFunc: 
     return
 }
 
-locate_inline_site:: proc(using data: ^SlimModData, pParent: CvsOffset, pcFromFunc: u32le) -> (site: ^SlimCvsInlineSite, src: ^SlimModInlineSrc){
+locate_inline_site:: proc(data: ^SlimModData, pParent: CvsOffset, pcFromFunc: u32le) -> (site: ^SlimCvsInlineSite, src: ^SlimModInlineSrc){
     // bisearch on a sorted acceleration structure
-    iStart := binary_search_min_ge(inlineSites, pParent, proc(v: CvsOffset, t: ^SlimCvsInlineSite) -> int {
+    iStart := binary_search_min_ge(data.inlineSites, pParent, proc(v: CvsOffset, t: ^SlimCvsInlineSite) -> int {
         //log.debugf("Comparing %v with %v", v, t.pParent)
         if v < t.pParent { return -1 }
         else if v > t.pParent { return 1 }
         else { return 0 }
     })
-    for i in iStart..<len(inlineSites) {
-        if inlineSites[i].pParent != pParent { break }
+    for i in iStart..<len(data.inlineSites) {
+        if data.inlineSites[i].pParent != pParent { break }
         found := false
-        for iline in inlineSites[i].lines {
+        for iline in data.inlineSites[i].lines {
             if iline.end > pcFromFunc && iline.offset <= pcFromFunc {
-                site = &inlineSites[i]
+                site = &data.inlineSites[i]
                 found = true
                 break
             }
@@ -246,13 +246,13 @@ locate_inline_site:: proc(using data: ^SlimModData, pParent: CvsOffset, pcFromFu
     }
     if site == nil { return }
 
-    iSite := binary_search_min_ge(inlineSrcs, site.inlinee, proc(v: CvItemId, t: ^SlimModInlineSrc) -> int {
+    iSite := binary_search_min_ge(data.inlineSrcs, site.inlinee, proc(v: CvItemId, t: ^SlimModInlineSrc) -> int {
         if v < t.inlinee { return -1 }
         else if v > t.inlinee { return 1 }
         else { return 0 }
     })
-    if iSite < len(inlineSrcs) && inlineSrcs[iSite].inlinee == site.inlinee {
-        src = &inlineSrcs[iSite]
+    if iSite < len(data.inlineSrcs) && data.inlineSrcs[iSite].inlinee == site.inlinee {
+        src = &data.inlineSrcs[iSite]
     }
     return
 }

--- a/vendor/pdb/pdb/pdbStream.odin
+++ b/vendor/pdb/pdb/pdbStream.odin
@@ -29,8 +29,8 @@ PdbStreamVersion :: enum u32le {
 PdbNamedStreamMap :: struct {
     strBuf : []byte, names : []PdbNamedStream,
 }
-find_named_stream :: proc(using this: PdbNamedStreamMap, name: string) -> (streamIdx: MsfStreamIdx) {
-    for ns in names {
+find_named_stream :: proc(this: PdbNamedStreamMap, name: string) -> (streamIdx: MsfStreamIdx) {
+    for ns in this.names {
         if strings.compare(ns.name, name) == 0 {
             return MsfStreamIdx(ns.streamIdx)
         }

--- a/vendor/pdb/pdb/stackTrace.odin
+++ b/vendor/pdb/pdb/stackTrace.odin
@@ -436,21 +436,21 @@ print_u64_x :: proc "contextless" (x: u64) #no_bounds_check {
 	runtime.stderr_write(a[i:])
 }
 
-print_source_code_location :: proc (using scl: runtime.Source_Code_Location) {
-    runtime.print_string(file_path)
+print_source_code_location :: proc (scl: runtime.Source_Code_Location) {
+    runtime.print_string(scl.file_path)
     when ODIN_ERROR_POS_STYLE == .Unix {
         runtime.print_byte(':')
-		runtime.print_u64(u64(line))
+		runtime.print_u64(u64(scl.line))
 		runtime.print_byte(':')
-		runtime.print_u64(u64(column))
+		runtime.print_u64(u64(scl.column))
 		runtime.print_byte(':')
     } else {
         runtime.print_byte('(')
-		runtime.print_u64(u64(line))
+		runtime.print_u64(u64(scl.line))
 		runtime.print_byte(':')
-		runtime.print_u64(u64(column))
+		runtime.print_u64(u64(scl.column))
 		runtime.print_byte(')')
     }
-    runtime.print_string(procedure)
+    runtime.print_string(scl.procedure)
     runtime.print_string("()\n")
 }

--- a/vendor/pdb/pdb/tpiStream.odin
+++ b/vendor/pdb/pdb/tpiStream.odin
@@ -39,15 +39,15 @@ TpiIndexOffsetBuffer :: struct {
 }
 TpiIndexOffsetPair :: struct #packed {ti: TypeIndex, offset: u32le,}
 
-seek_for_tpi :: proc(using this: TpiIndexOffsetBuffer, ti : TypeIndex, tpiStream: ^BlocksReader) -> (ok: bool) {
+seek_for_tpi :: proc(this: TpiIndexOffsetBuffer, ti : TypeIndex, tpiStream: ^BlocksReader) -> (ok: bool) {
     // bisearch then linear seaarch proc
-    lo, hi := 0, (len(buf)-1)
-    if hi < 0 || buf[lo].ti > ti || buf[hi].ti < ti { return false }
+    lo, hi := 0, (len(this.buf)-1)
+    if hi < 0 || this.buf[lo].ti > ti || this.buf[hi].ti < ti { return false }
     // ti in range, do a bisearch
     for lo <= hi {
         //log.debugf("Find block [%v, %v) for ti%v", lo,hi, ti)
         mid := lo + ((hi-lo)>>1)
-        mv := buf[mid].ti
+        mv := this.buf[mid].ti
         if mv == ti {
             lo = mid + 1
             break
@@ -60,10 +60,10 @@ seek_for_tpi :: proc(using this: TpiIndexOffsetBuffer, ti : TypeIndex, tpiStream
     if lo > 0 { lo -= 1 }
     //log.debugf("Find block [%v, %v) for ti%v", lo,lo+1, ti)
     // now a linear search from lo to high
-    tIdx := buf[lo].ti
-    tpiStream.offset = cast(uint)buf[lo].offset
+    tIdx := this.buf[lo].ti
+    tpiStream.offset = cast(uint)this.buf[lo].offset
     endOffset := tpiStream.size
-    if lo+1 < len(buf) { endOffset = cast(uint)buf[lo+1].offset }
+    if lo+1 < len(this.buf) { endOffset = cast(uint)this.buf[lo+1].offset }
     for ;tpiStream.offset < endOffset && tIdx != ti; tIdx+=1 {
         cvtHeader := read_packed(tpiStream, CvtRecordHeader)
         tpiStream.offset += cast(uint)cvtHeader.length - size_of(CvtRecordKind)


### PR DESCRIPTION
Corrects compilation errors using the latest version of Odin.
Adding the feature flag from the error messages didn't seem to work for some reason.
Luckily it was only being used in a few places.