### PR TITLE
`core:os/os2` migration

### DIFF
--- a/allocator.odin
+++ b/allocator.odin
@@ -284,7 +284,7 @@ tracking_allocator_print_results :: proc(t: ^Tracking_Allocator, type: Result_Ty
 		}
 	}
 
-	extra_threads := max(0, min(os.processor_core_count() - 1, trace_count - 1))
+	extra_threads := max(0, min(os.get_processor_core_count() - 1, trace_count - 1))
 	extra_threads_done: sync.Wait_Group
 	sync.wait_group_add(&extra_threads_done, extra_threads + 1)
 

--- a/back.odin
+++ b/back.odin
@@ -5,6 +5,7 @@ import "core:io"
 import "core:os"
 import "base:runtime"
 import "core:text/table"
+@(require) import "core:sys/posix"
 
 // Size of a constant backtrace, as used by the allocator for example.
 BACKTRACE_SIZE :: #config(BACKTRACE_SIZE, 16)
@@ -38,12 +39,12 @@ Line :: struct {
 	symbol:   string,
 }
 
-EAGAIN :: os.EAGAIN when ODIN_OS == .Linux || ODIN_OS == .Darwin else 5
-ENOMEM :: os.ENOMEM when ODIN_OS == .Linux || ODIN_OS == .Darwin else 6
-EFAULT :: os.EFAULT when ODIN_OS == .Linux || ODIN_OS == .Darwin else 7
-EMFILE :: os.EMFILE when ODIN_OS == .Linux || ODIN_OS == .Darwin else 8
-ENFILE :: os.ENFILE when ODIN_OS == .Linux || ODIN_OS == .Darwin else 9
-ENOSYS :: os.ENOSYS when ODIN_OS == .Linux || ODIN_OS == .Darwin else 10
+EAGAIN :: posix.EAGAIN when ODIN_OS == .Linux || ODIN_OS == .Darwin else 5
+ENOMEM :: posix.ENOMEM when ODIN_OS == .Linux || ODIN_OS == .Darwin else 6
+EFAULT :: posix.EFAULT when ODIN_OS == .Linux || ODIN_OS == .Darwin else 7
+EMFILE :: posix.EMFILE when ODIN_OS == .Linux || ODIN_OS == .Darwin else 8
+ENFILE :: posix.ENFILE when ODIN_OS == .Linux || ODIN_OS == .Darwin else 9
+ENOSYS :: posix.ENOSYS when ODIN_OS == .Linux || ODIN_OS == .Darwin else 10
 
 Lines_Error :: enum {
 	None,
@@ -125,7 +126,7 @@ register_segfault_handler :: proc() {
 }
 
 print :: proc(lines: []Line, padding := "    ", w: Maybe(io.Writer) = nil, no_temp_guard := false) {
-	w := w.? or_else os.stream_from_handle(os.stderr)
+	w := w.? or_else os.to_writer(os.stderr)
 
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD(ignore=no_temp_guard)
 

--- a/back_linux.odin
+++ b/back_linux.odin
@@ -23,7 +23,7 @@ program_init :: proc "contextless" () {
 	if PROGRAM == "" {
 		PROGRAM = os.args[0]
 		if !filepath.is_abs(PROGRAM) {
-			if abs, ok := filepath.abs(PROGRAM); ok {
+			if abs, err := filepath.abs(PROGRAM, context.allocator); err == nil {
 				PROGRAM = abs
 			} else {
 				fmt.eprintln("back: could not convert `os.args[0]` to an absolute path")


### PR DESCRIPTION
Adapts to `core:os/os2` becoming the new `core:os` (supposedly waiting for odin dev-2026-03 to become a release tag)